### PR TITLE
Prevent adding two consecutive blank lines at the end of new section

### DIFF
--- a/src/towncrier/_writer.py
+++ b/src/towncrier/_writer.py
@@ -40,5 +40,7 @@ def append_to_newsfile(
         f.write(top_line.encode("utf8"))
         f.write(content.encode("utf8"))
         if existing_content[0]:
-            f.write(b"\n\n")
+            # NOTE: The content that was written in the previous line already
+            # includes an empty line at the end.
+            f.write(b"\n")
         f.write(existing_content[0].lstrip().encode("utf8"))

--- a/src/towncrier/test/test_write.py
+++ b/src/towncrier/test/test_write.py
@@ -74,7 +74,6 @@ Bugfixes
 
 - Web fixed. (#3)
 
-
 Old text.
 """
 
@@ -182,7 +181,6 @@ Bugfixes
 ~~~~~~~~
 
 - Web fixed. (#3)
-
 
 Old text.
 """


### PR DESCRIPTION
This prevents the multiple consecutive blank lines error if one uses markdownlint to lint the Change Log.